### PR TITLE
Amélioration du temps d'indexation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,5 +35,6 @@ jobs:
           curl -fsSL "$ELASTICSEARCH_URL/_cat/health?h=status"
       - name: Run tests
         env:
+          INDEX_CHUNK_SIZE: 100
           ELASTICSEARCH_URL: http://localhost:${{ job.services.elasticsearch.ports[9200] }}
         run: npm test -- --forceExit

--- a/package.json
+++ b/package.json
@@ -4,11 +4,10 @@
   "description": "Indexation of french companies from INSEE's database",
   "main": "src/index.ts",
   "scripts": {
-    "scalingo-postbuild": "npm run build && npm prune --production",
     "build": "tsc",
     "watch": "tsc -w",
     "types": "tsc -noEmit",
-    "start": "npm run build",
+    "start": "npx --yes http-server",
     "index": "npm run index:sirene && npm run index:siret",
     "preindex:dev": "export NODE_ENV=dev && docker-compose up -d elasticsearch && npm run build && npm run index:sirene && npm run index:siret",
     "index:dev": "npm run index:sirene:dev && npm run index:siret:dev",

--- a/src/commands/__tests__/index.integration.ts
+++ b/src/commands/__tests__/index.integration.ts
@@ -61,8 +61,6 @@ describe("Perform indexation", () => {
         }
       }
     };
-    // wait for the ES refresh cycle of 1sec
-    await new Promise(resolve => setTimeout(resolve, 1000));
 
     await elasticSearchClient.search(searchRequest).then(r => {
       if (r.body.timed_out) {
@@ -94,11 +92,10 @@ describe("Perform indexation", () => {
       body: {
         query: {
           match_all: {}
-        }
+        },
+        size: 300
       }
     };
-    // wait for the ES refresh cycle of 1sec
-    await new Promise(resolve => setTimeout(resolve, 1000));
 
     await elasticSearchClient.search(searchRequest).then(r => {
       if (r.body.timed_out) {

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -20,7 +20,7 @@ const LOG_TO_HTTP =
 const logFormat = format.combine(
   format.label({ label: "trackdechets-sirene-search" }),
   format.timestamp({
-    format: "HH-MM:ss YYYY-MM-DD"
+    format: "HH-mm:ss YYYY-MM-DD"
   }),
   format.prettyPrint(),
   format.colorize(),

--- a/src/indexation/__tests__/bulkIndex.test.ts
+++ b/src/indexation/__tests__/bulkIndex.test.ts
@@ -38,7 +38,7 @@ describe("bulkIndexByChunks", () => {
   test("Should immediately send a request if body size is less than CHUNK_SIZE", async () => {
     // One document to index
     const bodyMock: ElasticBulkNonFlatPayload = [
-      [{ index: { _id: "1", _index: indexNameMock } }, { field: "value1" }]
+      [{ index: { _index: indexNameMock } }, { field: "value1" }]
     ];
     await bulkIndexByChunks(bodyMock, indexConfigMock, indexNameMock);
     expect(esClientMock).toHaveBeenCalledTimes(1);
@@ -74,10 +74,7 @@ describe("bulkIndexByChunks", () => {
   test("Should call dataFormatterFn if it is a function", async () => {
     // One document to index
     const bodyMock: ElasticBulkNonFlatPayload = [
-      [
-        { index: { _id: "1", _index: indexNameMock } },
-        { my_document_field: "value1" }
-      ]
+      [{ index: { _index: indexNameMock } }, { my_document_field: "value1" }]
     ];
     await bulkIndexByChunks(bodyMock, indexConfigMock, indexNameMock);
     expect(indexConfigMock.dataFormatterFn).toHaveBeenCalled();

--- a/src/indexation/__tests__/bulkIndex.test.ts
+++ b/src/indexation/__tests__/bulkIndex.test.ts
@@ -24,24 +24,14 @@ describe("bulkIndexByChunks", () => {
     dataFormatterFn: dataFormatterFnMock
   };
   const indexNameMock = "test_index";
-  const CHUNK_SIZE = 100;
+  const CHUNK_SIZE = parseInt(`${process.env.INDEX_CHUNK_SIZE}`, 10) || 100;
 
   beforeEach(() => {
     process.env.TD_SIRENE_INDEX_MAX_CONCURRENT_REQUESTS = "1";
-    process.env.INDEX_CHUNK_SIZE = `${CHUNK_SIZE}`;
     esClientMock.mockReset();
     dataFormatterFnMock.mockReset();
     esClientMock.mockImplementation(() => Promise.resolve());
     dataFormatterFnMock.mockImplementation((body, _) => Promise.resolve(body));
-  });
-
-  test("Should immediately send a request if body size is less than CHUNK_SIZE", async () => {
-    // One document to index
-    const bodyMock: ElasticBulkNonFlatPayload = [
-      [{ index: { _index: indexNameMock } }, { field: "value1" }]
-    ];
-    await bulkIndexByChunks(bodyMock, indexConfigMock, indexNameMock);
-    expect(esClientMock).toHaveBeenCalledTimes(1);
   });
 
   test("Should slice the body into chunks and send each as a separate request", async () => {
@@ -72,10 +62,12 @@ describe("bulkIndexByChunks", () => {
   });
 
   test("Should call dataFormatterFn if it is a function", async () => {
-    // One document to index
-    const bodyMock: ElasticBulkNonFlatPayload = [
-      [{ index: { _index: indexNameMock } }, { my_document_field: "value1" }]
-    ];
+    const bodyMock: ElasticBulkNonFlatPayload = Array(CHUNK_SIZE + 1)
+      .fill(0)
+      .map((_, i) => [
+        { index: { _id: `${i}`, _index: indexNameMock } },
+        { my_document_field: `value${i}` }
+      ]);
     await bulkIndexByChunks(bodyMock, indexConfigMock, indexNameMock);
     expect(indexConfigMock.dataFormatterFn).toHaveBeenCalled();
   });

--- a/src/indexation/elasticSearch.helpers.ts
+++ b/src/indexation/elasticSearch.helpers.ts
@@ -308,6 +308,13 @@ export const bulkIndexByChunks = async (
   bodyBuffer = [];
 };
 
+export const flushBuffer = async (
+  indexConfig: IndexProcessConfig,
+  indexName: string
+) => {
+  await request(indexName, indexConfig, bodyBuffer);
+};
+
 /**
  * Writable stream that parses CSV to an ES bulk body
  */
@@ -355,6 +362,11 @@ const getWritableParserAndIndexer = (
       )
         .then(() => next())
         .catch(err => next(err));
+    },
+    final: async callback => {
+      // Because we buffer chunks, we need to flush it at the end
+      await flushBuffer(indexConfig, indexName);
+      callback();
     }
   });
 

--- a/src/indexation/types.ts
+++ b/src/indexation/types.ts
@@ -28,7 +28,6 @@ export interface ElasticBulkIndexError {
 
 type ElasticBulkPrepayload = {
   index: {
-    _id: string;
     _index: string;
     // Next major ES version won't need _type anymore
     _type?: "_doc";


### PR DESCRIPTION
Proposition de quelques modifs mineures:
- désactiver les refresh, et refresh manuellement en one shot à la fin d'un process d'indexation. Il faudra penser à couper le refresh sur les index déjà existants si on part la dessus
- ne plus générer d'ID mais laisser ES affecter un ID à chaque élément. Si on affecte nous même un ID, ES doit checker pour chaque élément si cet identifiant existe déjà avant de pouvoir insérer l'élément, ce qui est assez couteux. Il faut cependant qu'on s'assure que lorsqu'on query on ne requête pas ce champ identifiant et plutot se baser sur le siret
- il m'a semblé qu'on avait un run de retry non batché en cas d'erreur 429 qui n'était pas nécessaire. La logique de wait & retry avec un temps exponentiel est me semble-t-il suffisante et évite de surcharger d'opérations ES
- lorsqu'on a plusieurs workers, le code attendait que tous les workers aient fini d'indexer avant de passer au batch suivant. Je propose de gérer un compteur de promesses en dehors du process d'indexation pour permettre que le nombre de workers affectés soit toujours utilisé à son maximum

Pour info, lors de mon dernier test sur un ES Scalingo starter 4GB, j'ai indexé les siret en 2h40 avec les paramètres suivants (contre environ 6h sur les derniers runs airflow, vers une gros ES 16gb redondé, mais qui a de la charge métier):
- INDEX_CHUNK_SIZE 10000
- TD_SIRENE_INDEX_MAX_CONCURRENT_REQUESTS 4
- TD_SIRENE_INDEX_MAX_HIGHWATERMARK 16384

Il m'a semblé contre productif de monter le highWaterMark dans mes tests, car la data est déjà bufferisée plus vite que ce que l'ES peut traiter, et donc augmenter la valeur ne faisait qu'augmenter la pression mémoire de la machine.