### PR TITLE
Correction sur l'hydratation des données SIREN

### DIFF
--- a/src/indexation/indexInsee.helpers.ts
+++ b/src/indexation/indexInsee.helpers.ts
@@ -94,6 +94,23 @@ const siretWithUniteLegaleFormatter = async (
   if (!body.length) {
     return [];
   }
+
+  const result: ElasticBulkNonFlatPayload = [];
+
+  const chunkSize = 10_000; // Max number of SIREN to search in one request
+  for (let i = 0; i < body.length; i += chunkSize) {
+    const chunk = body.slice(i, i + chunkSize);
+    const chunkResult = await siretWithUniteLegaleChunkFormatter(chunk, extras);
+    result.push(...chunkResult);
+  }
+
+  return result;
+};
+
+const siretWithUniteLegaleChunkFormatter = async (
+  body: ElasticBulkNonFlatPayload,
+  extras: { sireneIndexConfig: IndexProcessConfig }
+): Promise<ElasticBulkNonFlatPayload> => {
   const response = await client.search({
     index: sireneIndexConfig.alias,
     body: {


### PR DESCRIPTION
Comme on doit passer par un search et non plus un get, on ne peut pas récupérer plus de 10_000 réponses.
Or, les chunks ont parfois +10_000 éléments.
Il faut donc traiter l'hydratation des données SIREN par chunk et non pas en une seule fois.