### PR TITLE
Map etatAdministratifEtablissement as keyword

### DIFF
--- a/src/indexation/indexInsee.helpers.ts
+++ b/src/indexation/indexInsee.helpers.ts
@@ -229,6 +229,9 @@ export const siretIndexConfig: IndexProcessConfig = {
           type: "text",
           copy_to: "td_search_companies"
         },
+        etatAdministratifEtablissement: {
+          type: "keyword"
+        },
         td_search_companies: {
           type: "text"
         }


### PR DESCRIPTION
Pour pouvoir faire une recherche par `term` on a besoin qu'il soit indexé en keyword.
Sinon `A` est indexé comme `a`, en minuscule, et la recherche par terme ne fonctionne pas
