### PR TITLE
Correction des URLs de la base SIRENE

### DIFF
--- a/src/commands/indexInseeSirene.ts
+++ b/src/commands/indexInseeSirene.ts
@@ -13,7 +13,7 @@ import { sireneIndexConfig } from "../indexation/indexInsee.helpers";
  */
 const sireneUrl =
   process.env.INSEE_SIRENE_URL ||
-  "https://files.data.gouv.fr/insee-sirene/StockUniteLegale_utf8.zip";
+  "https://object.files.data.gouv.fr/data-pipeline-open/siren/stock/StockUniteLegale_utf8.zip";
 
 process.on("exit", function () {
   console.log(`Command index:sirene finished`);

--- a/src/indexation/indexInsee.helpers.ts
+++ b/src/indexation/indexInsee.helpers.ts
@@ -149,7 +149,7 @@ const siretWithUniteLegaleChunkFormatter = async (
  */
 export const siretUrl =
   process.env.INSEE_SIRET_URL ||
-  "https://files.data.gouv.fr/insee-sirene/StockEtablissement_utf8.zip";
+  "https://object.files.data.gouv.fr/data-pipeline-open/siren/stock/StockEtablissement_utf8.zip";
 
 export const siretIndexConfig: IndexProcessConfig = {
   alias: `${INDEX_NAME_INSEE_PREFIX}etablissement${INDEX_ALIAS_NAME_SEPARATOR}${


### PR DESCRIPTION
Les URLs de la base SIRENE ont changé sur data.gouv, j'ai mis à jour les valeurs par défaut dans les fichiers appropriés.

---

- [Ticket Favro]()
